### PR TITLE
GAME-5213 Use the Content-MD5 header for PUT

### DIFF
--- a/src/s3_server.erl
+++ b/src/s3_server.erl
@@ -170,7 +170,8 @@ handle_request(Req, C, StartTs, Attempts) ->
         {error, Reason} when Attempts < C#config.max_retries andalso
                              (Reason =:= connect_timeout orelse
                               Reason =:= connection_closed orelse
-                              Reason =:= timeout) ->
+                              Reason =:= timeout orelse
+                              Reason =:= bad_digest) ->
             catch (C#config.retry_callback)(Reason, Attempts),
             timer:sleep(C#config.retry_delay),
             handle_request(Req, C, StartTs, Attempts + 1);


### PR DESCRIPTION
`{error, bad_digest}` is returned if the file was corrupted over the network.
It's assumed that it's worth retrying the request in such a case.

Note that using the `Content-MD5` header also means changes to the signature in `Authorization:`